### PR TITLE
manifest: Drop redbull-kernel

### DIFF
--- a/snippets/remove.xml
+++ b/snippets/remove.xml
@@ -43,6 +43,7 @@
   <remove-project name="device/google/coral-sepolicy" />
   <remove-project name="device/google/redbull" />
   <remove-project name="device/google/redbull-sepolicy" />
+  <remove-project name="device/google/redbull-kernel" />
   <remove-project name="device/google/redfin" />
   <remove-project name="device/google/redfin-sepolicy" />
   <remove-project name="device/google/sunfish" />


### PR DESCRIPTION
* redfin-kernel and bramble-kernel were merged into redbull-kernel in r33.