### PR TITLE
lineage: Switch to 20.0 for bootctrl

### DIFF
--- a/snippets/lineage.xml
+++ b/snippets/lineage.xml
@@ -21,7 +21,7 @@
   <project path="external/vim" name="android_external_vim" remote="lineage" />
 
   <!-- Hardware -->
-  <project path="hardware/qcom-caf/bootctrl" name="android_hardware_qcom_bootctrl" remote="lineage" revision="lineage-19.0-caf" />
+  <project path="hardware/qcom-caf/bootctrl" name="android_hardware_qcom_bootctrl" remote="lineage" revision="lineage-20.0-caf" />
 
   <!-- Packages -->
   <project path="packages/apps/DeskClock" name="android_packages_apps_DeskClock" remote="lineage" />


### PR DESCRIPTION
- lineage-20.0-caf has more improvements and support for newer boot control HAL.

Signed-off-by: Cyber Knight <cyberknight755@gmail.com>